### PR TITLE
SHA instead of {tag, SHA}.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ from the top level directory of your project like this:
     rebar lock-deps
 
 The generated `rebar.config.lock` file lists every dependency of the
-project and locks it at the git revision found in the `deps` directory
-using the `{tag, SHA}` syntax.
+project and locks it at the git revision found in the `deps` directory.
 
 A clean build using the lock file (`rebar -C rebar.config.lock`) will
 pull all dependencies as found at the time of generation. Suggestions
@@ -23,7 +22,7 @@ Add the following to your top-level rebar.config:
     %% Plugin dependency
     {deps, [
     	{rebar_lock_deps_plugin, ".*",
-         {git, "git://github.com/seth/rebar_lock_deps_plugin.git", "master"}}
+         {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {branch, "master"}}}
     ]}.
 
     %% Plugin usage
@@ -43,7 +42,7 @@ the rebar.config files inside each directory in deps (non-recursively)
 along with the top-level rebar.config. Using this data, the script
 creates a new rebar.config.lock file as a clone of the top-level
 rebar.config file, but with the `deps` key replaced with the complete
-list of dependencies set to `{tag, SHA}` where the SHA is based on
+list of dependencies set to SHA that is based on
 what is currently checked out.
 
 If something fails during the get-deps rebar stage, take care to run

--- a/src/rebar_lock_deps_plugin.erl
+++ b/src/rebar_lock_deps_plugin.erl
@@ -6,7 +6,7 @@
 %%
 %% The lock-deps command generates an alternate rebar.config file that
 %% lists every dependency of a project and locks them at the git
-%% revision found in the deps directory using the `{tag, SHA}' syntax.
+%% revision found in the deps directory.
 %%
 %% Basic usage is:
 %% ```
@@ -107,7 +107,7 @@ write_rebar_lock(OrigPath, NewPath, NewDeps) ->
     ok.
 
 lock_dep({Name, _Version, {Git, Url, _Tag}}, Sha) ->
-    {Name, ".*", {Git, Url, {tag, Sha}}}.
+    {Name, ".*", {Git, Url, Sha}}.
 
 %% Find the git SHA1s of all the dependencies in `DepsDir' and return
 %% as a list of {Name, Sha} tuples where Name is an atom and Sha is a


### PR DESCRIPTION
Using {tag, SHA} is not a correct way to specify SHA.
If you look at rebar_deps.erl you'll see the following:

update_source1(AppDir, {git, _Url, {tag, Tag}}) ->
    ShOpts = [{cd, AppDir}],
    rebar_utils:sh("git fetch --tags origin", ShOpts),
    rebar_utils:sh(?FMT("git checkout -q ~s", [Tag]), ShOpts);

"git fetch --tags origin" only fetches commits for tags, no more.
If there are no tags in repo then no commits will be fetched.
