### PR TITLE
Respect rebar.config.script by using  rebar_config:consult_file/1

### DIFF
--- a/test/fake_erchef/deps/chef_authn/rebar.config
+++ b/test/fake_erchef/deps/chef_authn/rebar.config
@@ -4,7 +4,9 @@
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 {deps, [
-          {envy, ".*",
-   {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
+        {envy, ".*",
+         {git, "git://github.com/manderson26/envy.git", {branch, "master"}}},
 
+        {bogus1, ".*",
+         {git, "git://github.com/nobody/bogus1.git", {branch, "master"}}}
  ]}.

--- a/test/fake_erchef/deps/chef_authn/rebar.config.script
+++ b/test/fake_erchef/deps/chef_authn/rebar.config.script
@@ -1,0 +1,3 @@
+Deps = proplists:get_value(deps, CONFIG).
+RealDeps = lists:keydelete(bogus1, 1, Deps).
+lists:keystore(deps, 1, CONFIG, {deps, RealDeps}).


### PR DESCRIPTION
Previously when reading deps, the plugin naively read the rebar.config
file using file:consult/1. However, projects can add or remove deps
via a rebar.config.script file. The gproc project uses this mechanism
to provide certains deps only if available.

With this patch, rebar_config:consult_file/1 is used to obtain the
deps data for each project. This will run the script file if present
and give the same result as rebar will see when running `rebar
get-deps`.

Also adding a safety check for missing dependencies to crash with some
useful debug info if this occurs.

Fixes issue #9 
