### PR TITLE
Minor fixes to accomodate a deprecation warning in OTP 19.0

### DIFF
--- a/src/rldp_util.erl
+++ b/src/rldp_util.erl
@@ -14,5 +14,5 @@ cmd_in_dir(Cmd, Dir) ->
     end.
 
 mktemp_name(Prefix) ->
-    <<Int:32/big-unsigned-integer>> = crypto:rand_bytes(4),
+    <<Int:32/big-unsigned-integer>> = crypto:strong_rand_bytes(4),
     lists:flatten([Prefix, io_lib:format("~8.16.0b", [Int])]).


### PR DESCRIPTION
Fixing the following compilation warning under OTP 19.0:

```
src/rldp_util.erl:17: Warning: crypto:rand_bytes/1 is deprecated and will be removed in a future release; use crypto:strong_rand_bytes/1
```
